### PR TITLE
Add system-monitor.sh to log CPU, memory and disk logging

### DIFF
--- a/scripts/monitor/system-monitor.sh
+++ b/scripts/monitor/system-monitor.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#System Monitoring Script
+
+
+LOG_DIR="/var/log/system-monitor"
+LOG_FILE="$LOG_DIR/system-monitor.log"
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+#Ensure log directory exists
+
+sudo mkdir -p "$LOG_DIR"
+sudo touch "$LOG_FILE"
+
+{
+	echo "----- System Monitor Log: $TIMESTAMP -----"
+	echo ""
+	echo ">> CPU Load (top -bn1 | head -n 5):"
+	top -bn1 | head -n 5
+	echo ""
+	echo ">> Memory Usage (free -h):"
+	free -h
+	echo ""
+	echo ">> Disk Usage (df -h):"
+	df -h
+	echo ""
+	echo "-----------------------------------------"
+	echo ""
+} | sudo tee -a "$LOG_FILE" > /dev/null


### PR DESCRIPTION
This PR adds a system monitoring script as part of Day 8 of the DevOps learning plan.

- Added `system-monitor.sh` under `scripts/monitor/`
- The script logs CPU, memory, and disk usage
- Log output is saved to `/var/log/system-monitor/system-monitor.log`
- Matches documentation described in `/docs/monitoring-script.md`
