### PR TITLE
Day9logrotation - Add log rotation support and fix cron compatibility for system-monitor.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,32 @@ scripts/
 
 ---
 
+### [x] Day 9 – Log Rotation and Script Improvements
+
+- Improved `system-monitor.sh` for cron compatibility:
+  - Removed all `sudo` commands
+  - Used `$HOME` for user-specific paths
+  - Ensured log directory exists without root privileges
+- Confirmed cron job works and logs are updating every 5 minutes
+- Documented updated behavior in `docs/system-monitoring.md`
+
+- Created `scripts/rotate/system-logrotate.sh`:
+  - Manually triggers log rotation using `logrotate`
+  - Prints success or failure with proper exit code check
+
+- Added `scripts/rotate/system-monitor.conf`:
+  - Template config for logrotate with user-based ownership
+  - Daily rotation, compression, 7 backups, `olddir` structure
+
+- Verified rotation works with:
+  - `sudo ./scripts/rotate/system-logrotate.sh`
+  - Log files move to `~/system-monitor-logs/old/` and compress
+
+- Documented the entire log rotation process in `docs/log-rotation.md`
+- Committed and pushed everything to `day9logrotation` branch via pull request
+
+---
+
 ##  Current Focus
-**Week 1: Git mastery and system monitoring scripts**
+**Git mastery and system monitoring scripts**
 

--- a/docs/log-rotation.md
+++ b/docs/log-rotation.md
@@ -1,0 +1,123 @@
+# Day 9 – Log Rotation with logrotate
+
+**Date:** 2025-07-13  
+**Goal:** Automatically archive and rotate system-monitor logs using `logrotate`.
+
+---
+
+## Overview
+
+To prevent logs from growing indefinitely, `logrotate` was configured to rotate and compress system-monitor logs daily, keeping the last 7 backups. A Bash script was created to manually trigger rotation, and a generic config template was added for reuse.
+
+---
+
+## File Structure
+
+```
+
+devops-learning/
+├── scripts/
+│   └── rotate/
+│       ├── system-logrotate.sh
+│       └── system-monitor.conf  # template config
+├── docs/
+│   └── log-rotation.md
+
+````
+
+---
+
+## Logrotate Configuration Template
+
+**Path:** `scripts/rotate/system-monitor.conf`
+
+```conf
+# Replace 'username' with your actual Linux username
+
+su username username
+
+/home/username/system-monitor-logs/system-monitor.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0640 username username
+    olddir /home/username/system-monitor-logs/old
+}
+````
+
+### Explanation
+
+- `su username username`: Run rotation as the user instead of root.
+- `daily`: Rotate logs every day.
+- `rotate 7`: Keep 7 previous logs.
+- `compress` / `delaycompress`: Compress rotated logs with a delay.
+- `olddir`: Move old logs to a subdirectory.
+- `notifempty`: Skip if the log is empty.
+- `create`: Automatically create a fresh log file with correct permissions.
+
+---
+
+## Manual Rotation Script
+
+**Path:** `scripts/rotate/system-logrotate.sh`
+
+This Bash script triggers logrotate manually using the specified config file.
+
+### Usage
+
+```bash
+sudo ./scripts/rotate/system-logrotate.sh
+```
+
+### What it does
+
+- Validates the config and log directory exist
+- Calls `logrotate` in verbose mode
+- Prints a success/failure message
+
+---
+
+## How to Use
+
+1. Copy the template config:
+
+   ```bash
+   sudo cp scripts/rotate/system-monitor.conf /etc/logrotate.d/system-monitor
+   ```
+
+2. Edit the copied file and replace `username` with your actual Linux username:
+
+   ```bash
+   sudo vim /etc/logrotate.d/system-monitor
+   ```
+
+3. Make sure the log directory exists:
+
+   ```bash
+   mkdir -p ~/system-monitor-logs/old
+   ```
+
+4. Trigger a rotation manually to test:
+
+   ```bash
+   sudo ./scripts/rotate/system-logrotate.sh
+   ```
+
+5. Check that the log was rotated and moved to the `old/` folder.
+
+---
+
+## Outcome
+
+- System-monitor logs are now automatically rotated and compressed.
+- Manual script works for testing or use in cron.
+- Config file is reusable for other machines with minimal edits.
+
+---
+
+**Author:** Danish Sajid
+**DevOps Learning Plan – Day 9**
+

--- a/docs/system-monitoring.md
+++ b/docs/system-monitoring.md
@@ -34,7 +34,8 @@ devops-learning/
   - Memory usage using `free -h`
   - Disk usage using `df -h`
 - Adds a timestamp header
-- Appends output to: `/var/log/system-monitor/system-monitor.log`
+- Appends output to: `~/system-monitor-logs/system-monitor.log`
+- Uses absolute paths and avoids `sudo` so it works reliably with cron
 
 ---
 
@@ -52,7 +53,7 @@ devops-learning/
 
 3. Check the output:
    ```bash
-   sudo tail -n 30 /var/log/system-monitor/system-monitor.log
+   tail -n 30 ~/system-monitor-logs/system-monitor.log
    ```
 
 ---
@@ -81,7 +82,7 @@ Mem: 7.6Gi used, 625Mi free
 
 To automate the script, a cron job was added to run it every 5 minutes.
 
-1. Find the full path to the script:
+1. Find the full absolute path to the script:
    ```bash
    realpath scripts/monitor/system-monitor.sh
    ```
@@ -93,7 +94,7 @@ To automate the script, a cron job was added to run it every 5 minutes.
 
 3. Add this line to run it every 5 minutes:
    ```cron
-   */5 * * * * /home/ubuntu/devops-learning/scripts/monitor/system-monitor.sh
+   */5 * * * * <absolute-path-to>/scripts/monitor/system-monitor.sh
    ```
 
 4. Confirm it's saved:
@@ -103,25 +104,27 @@ To automate the script, a cron job was added to run it every 5 minutes.
 
 5. After 5–10 minutes, verify logs are updating:
    ```bash
-   sudo tail -n 30 /var/log/system-monitor/system-monitor.log
+   tail -n 30 ~/system-monitor-logs/system-monitor.log
    ```
 
 ---
 
 ## Notes
 
-- Cron uses a minimal environment, so always use absolute paths.
-- The script writes logs to `/var/log/system-monitor/` and may require `sudo` to create or write to that directory.
-- Log entries are timestamped, which helps with tracking system performance over time.
-- This is a basic form of monitoring. In a real production environment, centralized logging tools would be used instead.
+- The script avoids using `sudo` to ensure it runs smoothly under a normal user via cron.
+- It writes logs to `~/system-monitor-logs/`, a directory the user owns.
+- Always use absolute paths in cron since it runs in a minimal environment.
+- Each log entry is timestamped, making it easier to track system performance trends over time.
+- This is a basic form of logging. In production, centralized monitoring (e.g., Prometheus + Grafana) would be preferred.
 
 ---
 
 ## Outcome
 
-- The system-monitoring script works as expected.
-- A cron job ensures logs are written automatically every 5 minutes.
-- Documentation and scripts committed to the DevOps learning repository.
+- The system-monitoring script runs correctly, both manually and automatically.
+- A cron job ensures logs are appended every 5 minutes.
+- Script was polished for readability and cron compatibility.
+- Documentation and script committed to the DevOps learning repository.
 
 ---
 

--- a/scripts/monitor/system-monitor.sh
+++ b/scripts/monitor/system-monitor.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 #System Monitoring Script
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/bin
 
-
-LOG_DIR="/var/log/system-monitor"
+LOG_DIR="/home/zoya/system-monitor-logs"
 LOG_FILE="$LOG_DIR/system-monitor.log"
 TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
 
 #Ensure log directory exists
 
-sudo mkdir -p "$LOG_DIR"
-sudo touch "$LOG_FILE"
+mkdir -p "$LOG_DIR"
+touch "$LOG_FILE"
 
 {
 	echo "----- System Monitor Log: $TIMESTAMP -----"
@@ -26,4 +26,4 @@ sudo touch "$LOG_FILE"
 	echo ""
 	echo "-----------------------------------------"
 	echo ""
-} | sudo tee -a "$LOG_FILE" > /dev/null
+} >> "$LOG_FILE"

--- a/scripts/rotate/system-logrotate.sh
+++ b/scripts/rotate/system-logrotate.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Logrotate Trigger Script for system-monitor logs
+
+CONFIG_FILE="/etc/logrotate.d/system-monitor"
+LOG_DIR="$HOME/system-monitor-logs"
+
+echo "[*] Running logrotate for: $CONFIG_FILE"
+
+# Check if config exists
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "[!] Logrotate config not found at $CONFIG_FILE"
+    exit 1
+fi
+
+# Check if log directory exists
+if [[ ! -d "$LOG_DIR" ]]; then
+    echo "[!] Log directory $LOG_DIR not found"
+    exit 1
+fi
+
+# Run logrotate in verbose mode
+sudo logrotate -f -v "$CONFIG_FILE"
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo "[✔] Log rotation completed successfully."
+else
+    echo "[✖] Log rotation failed with exit code $EXIT_CODE."
+fi
+

--- a/scripts/rotate/system-monitor.conf
+++ b/scripts/rotate/system-monitor.conf
@@ -1,0 +1,15 @@
+# Replace 'username' with your actual Linux username
+
+su username username
+
+/home/username/system-monitor-logs/system-monitor.log {
+    daily
+    rotate 7
+    missingok
+    compress
+    delaycompress
+    notifempty
+    create 0640 username username
+    olddir /home/username/system-monitor-logs/old
+}
+


### PR DESCRIPTION
This PR adds system-logrotate.sh, system-monitor.conf and log-rotation.md. It also fixes the system-monitor.sh to run better with cron by removing sudo.
- Fixed 'scripts/monitor/system-monitor.sh' and documentation for it in 'docs/system-monitoring.md'
- Added 'scripts/system-logrotate.sh' that can be run manually to rotate logs
- Added 'scripts/system-monitor.conf' that can be copied  and edited to be used
- Added 'docs/log-rotation.md' that documents the process with instructions to reproduce on other machines
- Updated 'README.md' with Day 9 progress